### PR TITLE
add no_std-support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,6 @@
 language: rust
 rust:
-  - 1.0.0
-  - 1.1.0
-  - 1.2.0
-  - 1.3.0
-  - 1.4.0
-  - 1.5.0
-  - 1.6.0
-  - 1.7.0
-  - 1.8.0
-  - 1.9.0
-  - 1.10.0
+  - 1.36.0 # minimum supported version where "#![no_std]" is stable
   - stable
   - beta
   - nightly

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Provides the `Boolinator` trait, which lets you use `Option` and `Result`-style 
 
 ## Compatibility
 
-`boolinator` is tested against Rust 1.0+.  *Exhaustively* so.
+`boolinator` is tested against Rust 1.0+ and can be used in `no_std`-crates.  *Exhaustively* so.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Provides the `Boolinator` trait, which lets you use `Option` and `Result`-style 
 
 ## Compatibility
 
-`boolinator` is tested against Rust 1.0+ and can be used in `no_std`-crates.  *Exhaustively* so.
+`boolinator` is tested against Rust 1.36+ and can be used in `no_std`-crates.  *Exhaustively* so.
 
 ## License
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,11 @@ Provides the [`Boolinator`](trait.Boolinator.html) trait, which lets you use `Op
 */
 // Can't have undocumented APIs!  Nosiree!
 #![deny(missing_docs)]
+#![no_std]
+
+#[cfg_attr(test, macro_use)]
+#[cfg(test)]
+extern crate alloc;
 
 /**
 This trait defines a number of combinator-style methods for use with `bool` values.


### PR DESCRIPTION
Hi! If you accept this PR and release it, `no_std`-crates can use this as dependency. Otherwise they don't compile.

You can verify this with these commands:
- `$ rustup target add thumbv7em-none-eabihf`
- `$ cargo check --target thumbv7em-none-eabihf`
